### PR TITLE
Resized SIRS NYP logo in About Us page

### DIFF
--- a/_about-us/0-about-us.md
+++ b/_about-us/0-about-us.md
@@ -8,7 +8,7 @@ collection_name: about-us
 
 <img src="/images-2021/AboutUs_SIRS_OurMission.png" style="width:100%;"> 
 
-<img src="/images-2021/AboutUs_SIRS-NYP Combined Logos.png" style="width:100%;">
+<img src="/images-2021/AboutUs_SIRS-NYP Combined Logos.png" style="width:50%;">
 
 <p>The Singapore Institute of Retail Studies (SIRS) is a Continuing Education & Training (CET) institute of Nanyang Polytechnic. Established in January 2006 as the first CET Institute in Singapore, SIRS’ excellent performance and track record has since won the conferment of the National CET Institute status, the pinnacle status for CET centres.</p>
 

--- a/_about-us/0-about-us.md
+++ b/_about-us/0-about-us.md
@@ -8,7 +8,7 @@ collection_name: about-us
 
 <img src="/images-2021/AboutUs_SIRS_OurMission.png" style="width:100%;"> 
 
-<img src="/images-2021/AboutUs_SIRS-NYP Combined Logos.png" style="width:50%;">
+<img src="/images-2021/AboutUs_SIRS-NYP Combined Logos.png" style="width:70%;">
 
 <p>The Singapore Institute of Retail Studies (SIRS) is a Continuing Education & Training (CET) institute of Nanyang Polytechnic. Established in January 2006 as the first CET Institute in Singapore, SIRS’ excellent performance and track record has since won the conferment of the National CET Institute status, the pinnacle status for CET centres.</p>
 


### PR DESCRIPTION
Reduced the size to 70% instead of 100%